### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
-    # @items = Item.all
+    @items = Item.all.order(id:"DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
-    @items = Item.all.order(id:"DESC")
+    @items = Item.all.order(id: 'DESC')
   end
 
   def new
@@ -23,5 +23,4 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image, :name, :explanation, :category_id, :state_id, :shipping_fee_burden_id, :prefecture_id,
                                  :delivery_day_id, :item_fee).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
-    @items = Item.all.order(id: 'DESC')
+    @items = Item.order(id: 'DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,7 +23,7 @@ class Item < ApplicationRecord
     validates :delivery_day_id
   end
 
-  validates :name, length: {maximum: 40}
+  validates :name, length: { maximum: 40 }
   validates :item_fee, format: /\A[0-9]+\z/,
                        numericality: {
                          greater_than_or_equal_to: 300,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <% unless @items.empty? %>
@@ -157,7 +157,7 @@
       <% else %> 
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,33 +126,35 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# <% unless @items.empty? %>
-        <%# <% @items.each do |item| %>
-          <%# <li class='list'> %>
-            <%# <%= link_to "#" do %>
-              <%# <div class='item-img-content'> %>
-                <%# <%= link_to image_tag(item.image, class: "item-img"),root_path %>
+      <% unless @items.empty? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= link_to image_tag(item.image, class: "item-img"), "#" %>
+                  <%# 購入済の場合に表示 %>
                   <%# <div class='sold-out'> %>
                     <%# <span>Sold Out!!</span> %>
                   <%# </div> %>
-              <%# </div> %>
-              <%# <div class='item-info'> %>
-                <%# <h3 class='item-name'> %>
-                  <%# <%= item.name %>
-                <%# </h3> %>
-                <%# <div class="item-price"> %>
-                  <%# <span><%= "販売価格#{item.item_fee}円"<br><%= item.shipping_fee_burden.name %>
-                  <%# </span> %>
-                  <%# <div class='star-btn'> %>
-                    <%# <%= image_tag "star.png", class:"star-icon" %>
-                    <%# <span class='star-cou/nt'>0</span> %>
-                  <%# </div> %>
-                <%# </div> %>
-              <%# </div> %>
-            <%# <% end %>
-          <%# </li> %>
-        <%# <% end %> 
-      <%# <% else %> 
+                  <%# 購入済の場合に表示 %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class="item-price">
+                  <span><%= "販売価格#{item.item_fee}円" %><br><%= item.shipping_fee_burden.name %>
+                  </span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-cou/nt'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %> 
+      <% else %> 
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -170,7 +172,7 @@
         </div>
         <% end %>
       </li>
-      <%# <% end %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
     association :user
-    name                 { 'テスト商品' }
-    explanation              { 'テストです。テストです。テストです。テストです。テストです。テストです。テストです。' }
-    item_fee { 50000 }
-    category_id             { 2 }
-    state_id            { 2 }
-    prefecture_id             { 2 }
-    shipping_fee_burden_id            { 2 }
-    delivery_day_id            { 2 }
+    name { 'テスト商品' }
+    explanation { 'テストです。テストです。テストです。テストです。テストです。テストです。テストです。' }
+    item_fee { 50_000 }
+    category_id { 2 }
+    state_id { 2 }
+    prefecture_id { 2 }
+    shipping_fee_burden_id { 2 }
+    delivery_day_id { 2 }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Item, type: :model do
     @user = create(:user)
     user = @user
     @item = build(:item)
-    @item.image = fixture_file_upload("/files/test.jpg")
-  end 
+    @item.image = fixture_file_upload('/files/test.jpg')
+  end
 
   describe '商品出品' do
     context '商品が出品できるとき' do
@@ -20,105 +20,103 @@ RSpec.describe Item, type: :model do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Image can't be blank")
-      end 
+      end
       it 'nameがないと出品できない' do
         @item.name = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Name can't be blank")
-      end 
+      end
       it 'nameが40文字以上だと出品できない' do
-        @item.name = "ああああああああああああああああああああああああああああああああああああああああああ"
+        @item.name = 'ああああああああああああああああああああああああああああああああああああああああああ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name is too long (maximum is 40 characters)")
-      end 
+        expect(@item.errors.full_messages).to include('Name is too long (maximum is 40 characters)')
+      end
       it 'expilationがないと出品できない' do
         @item.explanation = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Explanation can't be blank")
-      end 
+      end
       it 'category_idがないと出品できない' do
         @item.category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category is not a number")
-      end 
+        expect(@item.errors.full_messages).to include('Category is not a number')
+      end
       it 'category_idが1だと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
-      end 
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
+      end
       it 'state_idがないと出品できない' do
         @item.state_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("State is not a number")
-      end 
+        expect(@item.errors.full_messages).to include('State is not a number')
+      end
       it 'state_idが1だと出品できない' do
         @item.state_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("State must be other than 1")
-      end 
+        expect(@item.errors.full_messages).to include('State must be other than 1')
+      end
       it 'shipping_fee_burden_idがないと出品できない' do
         @item.shipping_fee_burden_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee burden is not a number")
-      end 
+        expect(@item.errors.full_messages).to include('Shipping fee burden is not a number')
+      end
       it 'shipping_fee_burden_idが1だと出品できない' do
         @item.shipping_fee_burden_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee burden must be other than 1")
-      end 
+        expect(@item.errors.full_messages).to include('Shipping fee burden must be other than 1')
+      end
       it 'prefecture_idがないと出品できない' do
         @item.prefecture_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture is not a number")
-      end 
+        expect(@item.errors.full_messages).to include('Prefecture is not a number')
+      end
       it 'prefecture_idが1だと出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
-      end 
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
+      end
       it 'delivery_day_idがないと出品できない' do
         @item.delivery_day_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day is not a number")
-      end 
+        expect(@item.errors.full_messages).to include('Delivery day is not a number')
+      end
       it 'delivery_day_idが1だと出品できない' do
         @item.delivery_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery day must be other than 1")
-      end 
+        expect(@item.errors.full_messages).to include('Delivery day must be other than 1')
+      end
       it 'item_feeがないと出品できない' do
         @item.item_fee = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee can't be blank", "Item fee is invalid", "Item fee は300円から9999999円の範囲で入力してください")
-      end 
+        expect(@item.errors.full_messages).to include("Item fee can't be blank", 'Item fee is invalid',
+                                                      'Item fee は300円から9999999円の範囲で入力してください')
+      end
       it 'item_feeが300未満だとと出品できない' do
         @item.item_fee = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee は300円から9999999円の範囲で入力してください")
-      end 
+        expect(@item.errors.full_messages).to include('Item fee は300円から9999999円の範囲で入力してください')
+      end
       it 'item_feeが10000000以下でないと出品できない' do
-        @item.item_fee = 10000000
+        @item.item_fee = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee は300円から9999999円の範囲で入力してください")
+        expect(@item.errors.full_messages).to include('Item fee は300円から9999999円の範囲で入力してください')
       end
       it 'item_feeが全角数字では出品できない' do
-        @item.item_fee = "３００"
+        @item.item_fee = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee は300円から9999999円の範囲で入力してください")
-      end 
+        expect(@item.errors.full_messages).to include('Item fee は300円から9999999円の範囲で入力してください')
+      end
       it 'item_feeが全角英字では出品できない' do
-        @item.item_fee = "ＡＡＡ"
+        @item.item_fee = 'ＡＡＡ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee は300円から9999999円の範囲で入力してください")
-      end 
+        expect(@item.errors.full_messages).to include('Item fee は300円から9999999円の範囲で入力してください')
+      end
       it 'item_feeが半角英字では出品できない' do
-        @item.item_fee = "aaa"
+        @item.item_fee = 'aaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item fee は300円から9999999円の範囲で入力してください")
-      end 
-      
+        expect(@item.errors.full_messages).to include('Item fee は300円から9999999円の範囲で入力してください')
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
# What
商品一覧表示機能の実装
# Why
- 出品した商品を一覧表示
- 上から、出品された日時が新しい順に表示
- 「画像/価格/商品名」の3つの情報について表示
- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができる

[ログイン中のユーザーが商品一覧表示ページを見られる様子](https://gyazo.com/97c132afa1082f70391871047b0c4796)
[ログアウト中のユーザーが商品一覧表示ページを見られる様子](https://gyazo.com/6c612cf8f0c5fbe1e63dd653ee6638b2)
[商品のデータがない場合に、ダミー商品が表示されている動画](https://gyazo.com/15f974c0938a1727d14946169fcd6128)